### PR TITLE
add flatpak packaging to test shortcuts from flatpak

### DIFF
--- a/.flatpak-manifest.json
+++ b/.flatpak-manifest.json
@@ -1,0 +1,26 @@
+{
+    "app-id": "org.nice.wayland_global_shortcut",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.8",
+    "sdk": "org.kde.Sdk",
+    "command": "wayland_global_shortcut",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri"
+    ],
+    "modules": [
+        {
+            "name": "wayland_global_shortcut",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "."
+                }
+            ]
+        }
+    ]
+}
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,3 +38,5 @@ target_link_libraries(wayland_global_shortcut
 )
 
 target_include_directories(wayland_global_shortcut PRIVATE ${CMAKE_BINARY_DIR})
+
+install(TARGETS wayland_global_shortcut DESTINATION ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ int
 main(int argc, char* argv[])
 {
   QApplication a(argc, argv);
-  QApplication::setApplicationName("TheAppName");
+  QApplication::setApplicationName("wayland_global_shortcut");
   QApplication::setOrganizationDomain("org.nice");
 
   auto* btn = new QPushButton("useless button");


### PR DESCRIPTION
Build flatpak using following command:
 flatpak-builder --force-clean --install --user app --install-deps-from=flathub .flatpak-manifest.json

Run flatpak:
 flatpak run org.nice.wayland_global_shortcut